### PR TITLE
Force utc_offset to use local time.

### DIFF
--- a/lib/extensions/time.rb
+++ b/lib/extensions/time.rb
@@ -9,6 +9,6 @@ class Time # :nodoc:
 
   private
   def utc_hours_offset
-    self.utc_offset/3600
+    self.localtime.utc_offset/3600
   end
 end


### PR DESCRIPTION
This is a shim to deal with ActiveSupport::TimeWithZone objects in
Rails. to_s_for_cap is not defined for these objects, so ActiveSupport
delegates the call to a new Time object. In the conversion from
TimeWithZone to Time, the timezone offset is lost. Using localtime gets
it back again.
