### PR TITLE
Fix GeoJSON polygon coordinates

### DIFF
--- a/lib/rcap/base/polygon.rb
+++ b/lib/rcap/base/polygon.rb
@@ -30,7 +30,7 @@ module RCAP
       # Returns GeoJSON representation of the polygon
       def to_geojson
         coordinates = @points.map { |point| [point.longitude, point.lattitude] }
-        { 'type' => 'Polygon', 'coordinates' => coordinates }.to_json
+        { 'type' => 'Polygon', 'coordinates' => [coordinates] }.to_json
       end
 
       # Returns a string representation of the polygon of the form

--- a/spec/cap_1_0/polygon_spec.rb
+++ b/spec/cap_1_0/polygon_spec.rb
@@ -103,7 +103,7 @@ describe(RCAP::CAP_1_0::Polygon) do
 
     context('to geojson') do
       it('should be valid geojson') do
-        expected = '{"type":"Polygon","coordinates":[[0,0],[1,1],[2,2]]}'
+        expected = '{"type":"Polygon","coordinates":[[[0,0],[1,1],[2,2]]]}'
         expect(@polygon.to_geojson).to eq expected
       end
     end

--- a/spec/cap_1_1/polygon_spec.rb
+++ b/spec/cap_1_1/polygon_spec.rb
@@ -99,7 +99,7 @@ describe(RCAP::CAP_1_1::Polygon) do
 
     context('to geojson') do
       it('should be valid geojson') do
-        expected = '{"type":"Polygon","coordinates":[[0,0],[1,1],[2,2]]}'
+        expected = '{"type":"Polygon","coordinates":[[[0,0],[1,1],[2,2]]]}'
         expect(@polygon.to_geojson).to eq expected
       end
     end

--- a/spec/cap_1_2/polygon_spec.rb
+++ b/spec/cap_1_2/polygon_spec.rb
@@ -85,8 +85,8 @@ describe(RCAP::CAP_1_2::Polygon) do
 
     context('to geojson') do
       it('should be valid geojson') do
-        expected = '{"type":"Polygon","coordinates":[[0,0],[1,1],[2,2],' \
-          '[0,0]]}'
+        expected = '{"type":"Polygon","coordinates":[[[0,0],[1,1],[2,2],' \
+          '[0,0]]]}'
         expect(@polygon.to_geojson).to eq expected
       end
     end


### PR DESCRIPTION
Coordinates of a polygon should be an array of coordinate arrays rather than a
single coordinate array.